### PR TITLE
Only ignore entry with the name ".git".

### DIFF
--- a/bin/ghar
+++ b/bin/ghar
@@ -127,7 +127,7 @@ class Repo:
         l = self.ls[:]
         found_one = False
         for f in l:
-            if re.match("^\.git.*$", f) or re.match("^\README.*$", f):
+            if re.match("^\.git$", f) or re.match("^\README.*$", f):
                 self.ls.remove(f)
             elif re.match("^\..+$", f):
                 found_one = True


### PR DESCRIPTION
Currently all the entries which name starts with `.git*` are ignored. This means you can't version files which name starts with `.git*` (global `.gitconfig` for example).

I have tweaked a regular expression to only ignore entry with the name `.git` which should in all scenarios be a repo specific .git directory.

I know this is not an ideal solution, because ghar folder is a Git repo itself which means that for example `.gitignore` file could either be a local `.gitignore` file or a tracked dot file with the same name.
