### PR TITLE
Improved handling of directories

### DIFF
--- a/bin/ghar
+++ b/bin/ghar
@@ -97,9 +97,11 @@ class Link:
     def __str__(self):
         return self.target
 
-    def __init__(self, path, collection = True):
+    def __init__(self, path, collection = True, base = None):
         self.path = path
         self.basename = os.path.basename(path)
+        if base is not None and os.path.isdir(base):
+            self.basename = os.path.relpath(path, base)
 
         format = "%s"
         if not collection: format = ".%s"
@@ -171,15 +173,17 @@ class Repo:
         dir_links = []
         ls = os.listdir(path)
         for fname in ls:
-            link = Link(os.path.join(path, fname))
+            if re.match('^\.git\/?$', fname):
+                continue
+            link = Link(os.path.join(path, fname), base=self.path)
             ok, link_status = link.status()
-            if link_status == "directory" :
+            if link_status == "directory":
                 new_path = os.path.join(path, fname)
                 dir_links += self.list_directory_links(new_path)
             elif link_status.startswith("link to "):
                 print "We can't yet handle non-ghar symlinks."
             else:
-                dir_links.append(Link(os.path.join(path, fname)))
+                dir_links.append(Link(os.path.join(path, fname), base=self.path))
         return dir_links
 
     def __str__(self):
@@ -189,12 +193,15 @@ class Repo:
         self.path = path
         self.basename = os.path.basename(path)
         self.ls = os.listdir(path)
-        self.is_collection = self._is_collection()
         self.links = []
+
+        # Checking whether it's a collection:
+        # (NB: this has the side-effect of pruning '.git/'!)
+        self.is_collection = self._is_collection()
         if self.is_collection:
             self.links += self.list_directory_links(path)
         else:
-            self.links.append(Link(path, collection = False))
+            self.links.append(Link(path, collection = False, base = self.path))
 
 #
 # ghar sub-commands


### PR DESCRIPTION
I frequently want to version _only parts_ of a dotfile directory.

For example, my dotfiles repo looks something like:

```
.vimrc
.vim/filetype.vim
.vim/ftplugin/mail.vim
.vim/ftplugin/help.vim
```

etc.

Obviously the directory `~/.vim` already exists (and probably also several subdirectories).  But I don't want to symlink the _whole thing_; `vundle` manages my plugins just fine.  So I extended `ghar` to be able to recurse into directories.
### Old ghar behavior:
1. Check `~/.vim`; see that it already exists
2. Complain that it can't install `~/.vim`
### New ghar behavior:
1. Check `~/.vim`, see that it already exists
2. **Recurse into `~/.vim` from repo; try linking individual files**

Note that if the directory _didn't_ already exist, the new `ghar` will symlink the whole directory just like before.
### Implementation approach

There are two main changes to the code.
1. I wrote a recursive function to process directories for "collection"-type
   repos.  It only recurses if:
   - the target is a directory
   - the directory already exists (and is not a non-ghar symlink)
2. The `Link` class constructor now takes an optional `base` argument.  This lets us use `os.path.relname` instead of `os.path.basename`; the latter trims off the leading directories (which causes, e.g., `dotfiles/.vim/ftplugin/mail.vim` to get linked to `~/mail.vim` rather than `~/.vim/ftplugin/mail.vim`).
