### PR TITLE
Fix bug where link_subcommand ignored repo arguments

### DIFF
--- a/bin/ghar
+++ b/bin/ghar
@@ -256,7 +256,7 @@ def _link_subcommand(args, action, error_msg):
     if args.repos:
         pull_repos = filter(lambda x: str(x) in args.repos, repos)
 
-    for repo in repos:
+    for repo in pull_repos:
         if not repo.has_git():
             print "%s: not a git repo" % str(repo)
         elif len(repo.links) <= 0:


### PR DESCRIPTION
I noticed that 'ghar install --status <repo>' still processed all my repos instead of the specific one I specified. Demo of test case and fixed case below:

mouse:~/ghar (master) $ git checkout philips-ghar/master 
Note: checking out 'philips-ghar/master'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b new_branch_name

HEAD is now at 1aea05a... Merge pull request #7 from chiphogg/directories

mouse:~/ghar ((1aea05a...)) $ ghar install --status dotfiles-hg/
dotfiles-git
 ok /Users/aff0/.gitconfig
 ok /Users/aff0/.gitignore_global
dotfiles-hg
 ok /Users/aff0/.hgignore_global
dotfiles-shell
 ok /Users/aff0/.bash_profile
 ok /Users/aff0/.vimrc

mouse:~/ghar ((1aea05a...)) $ git checkout fix-link-subcommand-ignores-repo-args 
Previous HEAD position was 1aea05a... Merge pull request #7 from chiphogg/directories
Switched to branch 'fix-link-subcommand-ignores-repo-args'

mouse:~/ghar (fix-link-subcommand-ignores-repo-args) $ ghar install --status dotfiles-hg
dotfiles-hg
 ok /Users/aff0/.hgignore_global

mouse:~/ghar (fix-link-subcommand-ignores-repo-args) $ 
