### PR TITLE
Fix issue with getting ghar_dir when sys.argv[0] is a relative path.

### DIFF
--- a/bin/ghar
+++ b/bin/ghar
@@ -312,7 +312,7 @@ def _init_repos():
 
 def main(args):
     # the ghar executable lives in <repo directory>/bin/ghar
-    args.ghar_dir = os.path.dirname(os.path.dirname(sys.argv[0]))
+    args.ghar_dir = os.path.dirname(os.path.dirname(os.path.abspath(sys.argv[0])))
     _init_repos()
     if len(repos) <= 0:
         sys.stderr.write("No repos found in %s\n" % args.ghar_dir)


### PR DESCRIPTION
Fix issue when ghar invoked with relative path ('bin/ghar' or 'ghar/bin/ghar')
or when 'ghar' invoked in ghar/ dir and relative path 'bin' is in the PATH
(e.g. when using Boxen).

Credit goes to github users @Flaeme and @danny316p for the fix.
## Issue Description

I was playing with the github Boxen project.  Unfortunately, it adds a relative path for 'bin' at the start of my PATH.  This exposes a problem with ghar when sys.argv[0] returns a relative path like 'bin/ghar' instead of the full absolute path the code expects. This results in ghar incorrectly reporting 'No repos found' or saying 'We can't yet handle non-ghar symlinks'.

sys.argv[0] may return a relative path when invoking 'ghar' within 'ghar/' dir and the relative path 'bin' is in PATH or when user invokes ghar with a relative path (e.g 'bin/ghar' or 'ghar/bin/ghar').
## Issue Test Cases

```
mouse:~/ghar (fix-relative-bin-path-issue) $ git checkout philips-ghar/master
Note: checking out 'philips-ghar/master'.
...
```
### Relative path issue

```
mouse:~/ghar ((13db390...)) $ bin/ghar status
No repos found in
Please read /README
mouse:~/ghar ((13db390...)) $ bin/ghar install --status
No repos found in
Please read /README
mouse:~/ghar ((13db390...)) $ cd ..
mouse:~ $ ghar/bin/ghar status
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
dotfiles-git: dirty
dotfiles-hg: clean
dotfiles-shell: dirty
mouse:~/ghar ((13db390...)) $ cd ghar
```
### 'bin' in PATH issue

```
mouse:~/ghar ((13db390...)) $ PATH=bin:$PATH
mouse:~/ghar ((13db390...)) $ ghar status
No repos found in
Please read /README
mouse:~/ghar ((13db390...)) $ ghar install --status
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
We can't yet handle non-ghar symlinks.
dotfiles-git: has no dotfiles
dotfiles-hg: has no dotfiles
dotfiles-shell: has no dotfiles
```
## Issue Test Cases After Fix

```
mouse:~/ghar ((13db390...)) $ git checkout fix-relative-bin-path-issue
Previous HEAD position was 13db390... Merge pull request #10 from githubaff0/fix-link-subcommand-ignores-repo-args
Switched to branch 'fix-relative-bin-path-issue'
```
### Relative path issue

```
mouse:~/ghar (fix-relative-bin-path-issue) $ bin/ghar status
dotfiles-git: dirty
dotfiles-hg: clean
dotfiles-shell: dirty
mouse:~/ghar (fix-relative-bin-path-issue) $ bin/ghar install --status
dotfiles-git
 ok /Users/githubaff0/.gitconfig
dotfiles-hg
 ok /Users/githubaff0/.hgignore_global
dotfiles-shell
 ok /Users/githubaff0/.bash_profile
 ok /Users/githubaff0/.bashrc
mouse:~/ghar (fix-relative-bin-path-issue) $ cd ..
mouse:~ $ ghar/bin/ghar status
dotfiles-git: dirty
dotfiles-hg: clean
dotfiles-shell: dirty
mouse:~/ghar (fix-relative-bin-path-issue) $ cd ghar
```
### 'bin' in PATH issue

```
mouse:~/ghar (fix-relative-bin-path-issue) $ ghar status
dotfiles-git: dirty
dotfiles-hg: clean
dotfiles-shell: dirty
mouse:~/ghar (fix-relative-bin-path-issue) $ ghar install --status
dotfiles-git
 ok /Users/githubaff0/.gitconfig
dotfiles-hg
 ok /Users/githubaff0/.hgignore_global
dotfiles-shell
 ok /Users/githubaff0/.bash_profile
 ok /Users/githubaff0/.bashrc    
```
