### PR TITLE
"Fix" directly linked folders.

### DIFF
--- a/bin/ghar
+++ b/bin/ghar
@@ -100,7 +100,7 @@ class Link:
     def __init__(self, path, collection = True, base = None):
         self.path = path
         self.basename = os.path.basename(path)
-        if base is not None and os.path.isdir(base):
+        if collection and base is not None and os.path.isdir(base):
             self.basename = os.path.relpath(path, base)
 
         format = "%s"


### PR DESCRIPTION
Don't try to make the basename of a link relative if the link is not a
collection, as the result is always the path ".". This was broken by #7.
This isn't an ideal fix as it doesn't handle the case where the target
already exists; it would be nice for it to merge recursively the way it
does for collections, but it's better than it failing entirely.
