### PR TITLE
Python3 compatability

### DIFF
--- a/bin/ghar
+++ b/bin/ghar
@@ -320,7 +320,11 @@ def main(args):
     if len(repos) <= 0:
         sys.stderr.write("No repos found in %s\n" % args.ghar_dir)
         sys.stderr.write("Please read %s/README\n" % args.ghar_dir)
-    args.func(args)
+    # Python3 doesn't error on parse_args with no subcommand.
+    if 'func' in args:
+        args.func(args)
+    else:
+        argp.print_help()
 
 if __name__ == "__main__":
     args = argp.parse_args()


### PR DESCRIPTION
Added python3 support, and gracefully falls back to python2 libs when required.

This will make ghar available for users who are in python3 environments, and retains python2 compatibility.
