### PR TITLE
Ignore .travis.yml files

### DIFF
--- a/bin/ghar
+++ b/bin/ghar
@@ -148,7 +148,7 @@ class Repo:
         found_one = False
         for f in l:
             # global .gitconfig as a config is OK but not .git/ or .gitignore
-            if re.match("^\.git(ignore|modules)?$", f) or re.match("^\README.*$", f):
+            if re.match("^\.git(ignore|modules)?$", f) or re.match("^\README.*$", f) or re.match("^\.travis.yml"):
                 self.ls.remove(f)
             elif re.match("^\..+$", f):
                 found_one = True


### PR DESCRIPTION
Some projects that contain shell content also use the travis-ci service to test their coed.

This ignores the .travis.yml file when considering if this directory contains dotfiles, or a directory to symlink.
