### PR TITLE
Regex fix for README

### DIFF
--- a/bin/ghar
+++ b/bin/ghar
@@ -148,7 +148,7 @@ class Repo:
         found_one = False
         for f in l:
             # global .gitconfig as a config is OK but not .git/ or .gitignore
-            if re.match("^\.git(ignore|modules)?$", f) or re.match("^\README.*$", f) or re.match("^\.travis.yml", f):
+            if re.match("^\.git(ignore|modules)?$", f) or re.match("^README.*$", f) or re.match("^\.travis.yml", f):
                 self.ls.remove(f)
             elif re.match("^\..+$", f):
                 found_one = True


### PR DESCRIPTION
Python 3.6.0 reports an error when running ghar. Removing the `\` before the R on the regex line fixes it for me:
```
Traceback (most recent call last):
  File "/home/jwong/ghar/bin/ghar", line 359, in <module>
    main(args)
  File "/home/jwong/ghar/bin/ghar", line 347, in main
    _init_repos()
  File "/home/jwong/ghar/bin/ghar", line 340, in _init_repos
    repos.append(Repo(os.path.join(root, dir)))
  File "/home/jwong/ghar/bin/ghar", line 229, in __init__
    self.is_collection = self._is_collection()
  File "/home/jwong/ghar/bin/ghar", line 151, in _is_collection
    if re.match("^\.git(ignore|modules)?$", f) or re.match("^\README.*$", f) or re.match("^\.travis.yml", f):
  File "/usr/lib/python3.6/re.py", line 172, in match
    return _compile(pattern, flags).match(string)
  File "/usr/lib/python3.6/re.py", line 301, in _compile
    p = sre_compile.compile(pattern, flags)
  File "/usr/lib/python3.6/sre_compile.py", line 562, in compile
    p = sre_parse.parse(p, flags)
  File "/usr/lib/python3.6/sre_parse.py", line 856, in parse
    p = _parse_sub(source, pattern, flags & SRE_FLAG_VERBOSE, False)
  File "/usr/lib/python3.6/sre_parse.py", line 415, in _parse_sub
    itemsappend(_parse(source, state, verbose))
  File "/usr/lib/python3.6/sre_parse.py", line 501, in _parse
    code = _escape(source, this, state)
  File "/usr/lib/python3.6/sre_parse.py", line 401, in _escape
    raise source.error("bad escape %s" % escape, len(escape))
sre_constants.error: bad escape \R at position 1
```